### PR TITLE
Minimal typescript props, events, methods

### DIFF
--- a/lib/compilers/react/typescript-generator/index.js
+++ b/lib/compilers/react/typescript-generator/index.js
@@ -6,8 +6,8 @@ const traversePhenomeComponent = require('../../../compiler-utils/traverse-pheno
 const dtsTemplate = `
 namespace {{name}} {
   export interface Props {
-     {{props}}
-     {{events}}
+      {{props}}
+      {{events}}
   }
 }
 export class {{name}} extends React.Component<{{name}}.Props, {}> {
@@ -133,15 +133,49 @@ function collectEvents(componentNode) {
   return events;
 }
 
+function renderProps(props, indent) {
+  return props.map(prop => {
+    return `${prop.name}${prop.required ? '' : '?'} : any`;
+  })
+  .join(`\n${indent}`)
+}
+
+function renderEvents(props, indent) {
+  return props.map(event => {
+    const handlerPropName = event.name.replace(/^([a-z])/, (_, initial) => initial.toUpperCase())
+    return `on${handlerPropName}? : Function`;
+  })
+  .join(`\n${indent}`)
+}
+
+function renderMethods(methods, indent) {
+  return methods.map(method => {
+    return `${method.name}(${method.arguments.map(a => `${a.name} : any`).join(', ')}) : unknown`;
+  })
+  .join(`\n${indent}`)
+}
+
 const generate = ({ name = 'MyComponent', ast, componentNode, state, config }) => {
   const camelCaseName = toCamelCase(name);
   const props = collectProps(componentNode);
-  const methods = collectMethods(componentNode);
+  const renderedProps = renderProps(props, '      ');
   const events = collectEvents(componentNode);
+  const renderedEvents = renderEvents(events, '      ');
+  const methods = collectMethods(componentNode);
+  const renderedMethods = renderMethods(methods, '  ');
 
   console.log({ props, methods, events });
 
-  let output = dtsTemplate.replace(/{{name}}/g, camelCaseName);
+  let output = dtsTemplate
+    .replace(/({{name}})|({{props}})|({{events}})|({{methods}})/g,
+      (_, name, props, events) =>
+        name
+          ? camelCaseName
+          : props
+            ? renderedProps
+              : events
+                ? renderedEvents
+                : renderedMethods);
 
   /*
   process output template with props, methods and events arrays


### PR DESCRIPTION

Cool!  Here's some of it filled in.

I didn't attempt to convert prop types into appropriate typescript types.  I'm skeptical that there is enough fidelity in this least-common-denominator type system - like, when we're getting back a `Route` or a `View`, react-proptypes will only represent that as an `Object`, right?  And it would be nice to include the jsdoc documentation for each thing, mirroring what you have in the online docs for F7 about each component.

Good point about abstracting from F7.  There are quite a few features like the core App component, the app-level extensions to it by each component's concerns, and reused F7 core types - if Phenome is agnostic, can it accommodate the core api somehow?

To save you the suspense, here's the generated output.  Again, there's more type information in your AST than is represented yet, but we need a mechanism for converting its prop types to the most appropriate typescript type:

```
namespace MyPhenomeComponent {
  export interface Props {
      foo? : any
      bar? : any
      fooBar? : any
      one : any
      two? : any
      onComponentOpen? : Function
      onComponentClose? : Function
  }
}
export class MyPhenomeComponent extends React.Component<MyPhenomeComponent.Props, {}> {
  open(animate : any) : unknown
  close(animate : any) : unknown
}
```

You don't have to really pull this in to your branch, a PR just seemed to be the easiest way to share it.