### PR TITLE
fix(typescript): the prop type doesn't need to include the default value

### DIFF
--- a/lib/compilers/react/typescript-generator/index.js
+++ b/lib/compilers/react/typescript-generator/index.js
@@ -66,9 +66,6 @@ function collectProps(componentNode, ast, input) {
         if (subProp.key.name === 'type') {
           prop.type = getPropType(subProp.value);
         }
-        if (subProp.key.name === 'default') {
-          prop.default = astToCode(subProp.value, { format: { compact: true } });
-        }
         if (subProp.key.name === 'required') {
           prop.required = subProp.value.value;
         }
@@ -187,7 +184,7 @@ function renderProps(props, indent) {
       if (prop.name === 'style' && type === 'Object') {
         type = 'React.CSSProperties';
       }
-      return `${prop.name}${prop.required ? '' : '?'} : ${type} ${prop.default ? ` | ${prop.default}` : ''} `;
+      return `${prop.name}${prop.required ? '' : '?'} : ${type} `;
     })
     .map(prop => prop.trim())
     .join(`\n${indent}`);
@@ -199,7 +196,7 @@ function renderEvents(props, indent) {
       const handlerPropName = event.name.replace(/^([a-z])/, (_, initial) => initial.toUpperCase());
       const args = event.arguments && event.arguments.length
         ? event.arguments.map(a => `${a}?: any`).join(', ')
-        : '...args?: any[]';
+        : '...args: any[]';
       return `on${handlerPropName}? : (${args}) => void`;
     })
     .join(`\n${indent}`);


### PR DESCRIPTION
the whole point is that the default value is never provided

plus, it was generating invalid TypeScript in messages.d.ts

Related: https://github.com/phenomejs/phenome/issues/11